### PR TITLE
Template modjk conf files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/apache_httpd-role/tree/develop)
-
+### Added
+- *Template mod_jk configuration files* @jnogol
 ## [1.1.0](https://github.com/idealista/apache_httpd-role/tree/1.1.0)
 ## [Full Changelog](https://github.com/idealista/apache_httpd-role/compare/1.0.0...1.1.0)
 ### Added

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -64,7 +64,7 @@ apache_modjk_download_dir: /tmp
 apache_modjk_build_dir: "{{ apache_modjk_download_dir }}/tomcat-connectors-{{ apache_modjk_version }}-src/native"
 ### If configuration for mod_jk is provided, this needs to be done in a file under {{ apache_modjk_playbook_files_dir }} folder in our playbook directory
 ### and these variables have to be set to true and to the name of such configuration file
-apache_modjk_playbook_files_dir: "{{ playbook_dir }}/files/apache/mod_jk"
+apache_modjk_playbook_files_dir: "{{ playbook_dir }}/templates/apache/mod_jk"
 apache_modjk_conf: false # Set true to copy a mod_jk config file
 apache_modjk_conf_file: # Name and extension of this file
 apache_modjk_workers_properties: false # Set true to copy a mod_jk workers properties file

--- a/tasks/install_modjk.yml
+++ b/tasks/install_modjk.yml
@@ -29,7 +29,7 @@
     chdir: "{{ apache_modjk_build_dir }}"
 
 - name: Apache_httpd | Copy mod_jk to Apache modules folder
-  template:
+  copy:
     src: "{{ apache_modjk_build_dir }}/apache-2.0/mod_jk.so"
     dest: "{{ apache_install_dir }}/modules/mod_jk.so"
     owner: "{{ apache_user }}"
@@ -46,7 +46,7 @@
   when: apache_modjk_conf
 
 - name: Apache_httpd | Copy mod_jk workers properties file
-  copy:
+  template:
     src: "{{ apache_modjk_playbook_files_dir }}/{{ apache_modjk_workers_properties_file }}"
     dest: "{{ apache_install_dir }}/conf/extra/{{ apache_modjk_workers_properties_file }}"
     owner: "{{ apache_user }}"

--- a/tasks/install_modjk.yml
+++ b/tasks/install_modjk.yml
@@ -29,7 +29,7 @@
     chdir: "{{ apache_modjk_build_dir }}"
 
 - name: Apache_httpd | Copy mod_jk to Apache modules folder
-  copy:
+  template:
     src: "{{ apache_modjk_build_dir }}/apache-2.0/mod_jk.so"
     dest: "{{ apache_install_dir }}/modules/mod_jk.so"
     owner: "{{ apache_user }}"
@@ -37,7 +37,7 @@
     remote_src: true
 
 - name: Apache_httpd | Copy mod_jk configuration file
-  copy:
+  template:
     src: "{{ apache_modjk_playbook_files_dir }}/{{ apache_modjk_conf_file }}"
     dest: "{{ apache_install_dir }}/conf/extra/{{ apache_modjk_conf_file }}"
     owner: "{{ apache_user }}"


### PR DESCRIPTION
### Description of the Change

Now mod_jk config file and workers properties file can be templated 

### Benefits

This way, variables like ports, worker names and so on can be set on a variables file and used in the config files, avoiding harcoding values.

### Possible Drawbacks

Now the files have to be under `templates/apache/mod_jk` folder instead of `files/apache/mod_jk`