### PR TITLE
Add group: deprecated-2017Q4 to Travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 ---
 language: python
 python: "2.7.13"
+group: deprecated-2017Q4
 
 sudo: required
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

Due to a change in Travis, there was a task that consistently was throwing time out, breaking the CI.

### Benefits

Restoring CI.

### Possible Drawbacks

No drawbacks found.