### PR TITLE
Use uvigo instead of rediris

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 ---
 language: python
 python: "2.7.13"
+group: deprecated-2017Q4
 
 sudo: required
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/apache_httpd-role/tree/develop)
+## [1.5.1](https://github.com/idealista/apache_httpd-role/tree/1.5.1)
+### Changed
+- *Use uvigo mirror for mod_jk instead of rediris* @jnogol
 
 ## [1.5.0](https://github.com/idealista/apache_httpd-role/tree/1.5.0)
 ### Added

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -8,7 +8,7 @@ apache_required_libs:
   - libpcre3-dev
   - make
 
-apache_modjk_url: http://apache.rediris.es/tomcat/tomcat-connectors/jk/tomcat-connectors-{{ apache_modjk_version }}-src.tar.gz
+apache_modjk_url: http://apache.uvigo.es/tomcat/tomcat-connectors/jk/tomcat-connectors-{{ apache_modjk_version }}-src.tar.gz
 apache_modjk_prerrequisites:
   - autoconf
   - libtool-bin


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

Using _uvigo_'s Apache mirror to download `mod_jk`.

### Benefits

Faster and more reliable `mod_jk` downloads.

### Possible Drawbacks

None.