### PR TITLE
Service variables, disable logrotate, new Apache default version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/apache_httpd-role/tree/develop)
+### Changed
+- *Update default Apache version to 2.4.33* @jnogol
+- *Disabled logrotate by default* @jnogol
+- *[#49](https://github.com/idealista/apache_httpd-role/issues/49) Extract service state and enabled option to variables* @jnogol
 
 ## [1.6.0](https://github.com/idealista/apache_httpd-role/tree/1.6.0)
 ## [Full Changelog](https://github.com/idealista/apache_httpd-role/compare/1.5.2...1.6.0)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,9 @@ apache_install_dir: /etc/apache2
 apache_logs_dir: /var/log/apache2
 apache_config_dir: "{{ apache_install_dir }}/conf"
 
+apache_service_state: started
+apache_service_enabled: yes
+
 apache_rewrites_template_src_folder: "{{ playbook_dir }}/templates/apache/rewrites"
 apache_rewrites_template_dest_folder: "{{ apache_install_dir }}/conf"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ apache_reinstall: false
 apache_user: apache
 apache_group: apache
 
-apache_version: 2.4.29
+apache_version: 2.4.33
 
 apache_build_dir: /tmp/build_apache
 apache_install_dir: /etc/apache2
@@ -42,30 +42,30 @@ apache_sites_enabled:
 ### The list of default modules can be found on:
 ### http://httpd.apache.org/docs/2.4/en/mod/#A
 apache_default_modules_enabled:
-  - authn_file
-  - authn_core
-  - authz_host
-  - authz_groupfile
-  - authz_user
-  - authz_core
   - access_compat
+  - alias
   - auth_basic
-  - reqtimeout
-  - filter
-  - mime
-  - log_config
-  - env
-  - headers
-  - setenvif
-  - version
-  - unixd
-  - status
+  - authn_core
+  - authn_file
+  - authz_core
+  - authz_groupfile
+  - authz_host
+  - authz_user
   - autoindex
   - dir
-  - alias
+  - env
+  - filter
+  - headers
+  - log_config
+  - mime
   - proxy
   - proxy_connect
   - proxy_http
+  - reqtimeout
+  - setenvif
+  - status
+  - unixd
+  - version
 
 ## mod_jk variables
 apache_modjk_install: false # Set to true to install mod_jk
@@ -81,7 +81,7 @@ apache_modjk_workers_properties: false # Set true to copy a mod_jk workers prope
 apache_modjk_workers_properties_file: # Name and extension of this file
 
 ## logrotate variables
-apache_logrotate_enabled: true
+apache_logrotate_enabled: false
 apache_logrotate_cron_settings: {hour: '3', minute: '0', user: 'root'}
 
 ## brotli variables

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -3,6 +3,6 @@
 - name: Apache_httpd | Configure httpd service
   systemd:
     name: apache2
-    state: started
-    enabled: yes
+    state: "{{ apache_service_state }}"
+    enabled: "{{ apache_service_enabled }}"
     daemon_reload: yes


### PR DESCRIPTION
- Fixes #49 
- Disable logrotate by default
- Default Apache version 2.4.33
