### PR TITLE
Features/several improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,20 @@ group: deprecated-2017Q4
 
 sudo: required
 
+env:
+  - ansible_version: 2.4.0.0
+  - ansible_version: 2.4.1.0
+  - ansible_version: 2.4.2.0
+  - ansible_version: 2.4.3.0
+  - ansible_version: 2.5.0.0
+
 services:
   - docker
+
 install:
-  - pip install ansible==2.4.0.0
+  - pip install ansible==${ansible_version}
   - pip install molecule==1.25.0
+  - pip install ansible-lint==3.4.20
   - pip install docker
 script:
   - molecule test --driver docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ sudo: required
 services:
   - docker
 install:
-  - pip install ansible==2.3.1.0
+  - pip install ansible==2.4.0.0
   - pip install molecule==1.25.0
   - pip install docker
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/apache_httpd-role/tree/develop)
+### Changed
+- *Update Brotli, mod_jk and Apache version* @jnogol
+- *Use import_tasks instead of include and therefore, Ansible minimum version = 2.4.0.0* @jnogol
 
 ## [1.6.0](https://github.com/idealista/apache_httpd-role/tree/1.6.0)
 ## [Full Changelog](https://github.com/idealista/apache_httpd-role/compare/1.5.2...1.6.0)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ These instructions will get you a copy of the role for your Ansible playbook. On
 
 ### Prerequisities
 
-Ansible 2.2.1.0 version installed.
+Ansible 2.4.0.0 version installed.
 Inventory destination should be a Debian environment.
 
 For testing purposes, [Molecule](https://molecule.readthedocs.io/) (version 1.25) with [Vagrant](https://www.vagrantup.com/) as driver (with [landrush](https://github.com/vagrant-landrush/landrush) plugin) and [VirtualBox](https://www.virtualbox.org/) or [Docker](https://www.docker.com/) as provider.
@@ -75,7 +75,7 @@ See molecule.yml to check possible testing platforms. As a reminder, our tests a
 
 ## Built With
 
-![Ansible](https://img.shields.io/badge/ansible-2.2.1.0-green.svg)
+![Ansible](https://img.shields.io/badge/ansible-2.4.0.0-green.svg)
 
 ## Versioning
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ apache_reinstall: false
 apache_user: apache
 apache_group: apache
 
-apache_version: 2.4.29
+apache_version: 2.4.33
 
 apache_build_dir: /tmp/build_apache
 apache_install_dir: /etc/apache2
@@ -66,7 +66,7 @@ apache_default_modules_enabled:
 
 ## mod_jk variables
 apache_modjk_install: false # Set to true to install mod_jk
-apache_modjk_version: 1.2.42
+apache_modjk_version: 1.2.43
 apache_modjk_download_dir: /tmp/build_modjk
 apache_modjk_build_dir: "{{ apache_modjk_download_dir }}/tomcat-connectors-{{ apache_modjk_version }}-src/native"
 ### If configuration for mod_jk is provided, this needs to be done in a file under {{ apache_modjk_playbook_files_dir }} folder in our playbook directory
@@ -83,6 +83,7 @@ apache_logrotate_cron_settings: {hour: '3', minute: '0', user: 'root'}
 
 ## brotli variables
 apache_brotli_install: false
+apache_brotli_reinstall: false
 apache_brotli_lib_path: /usr/lib/brotli
 apache_brotli_build_path: /tmp/brotli
-apache_brotli_version: v1.0.2
+apache_brotli_version: v1.0.3

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,7 @@
 galaxy_info:
   company: Idealista S.A.U.
   description: Apache HTTP Server role
-  min_ansible_version: 2.2.1.0
+  min_ansible_version: 2.4.0.0
   license: Apache 2.0
   platforms:
     - name: Debian

--- a/molecule.yml
+++ b/molecule.yml
@@ -28,11 +28,6 @@ ansible:
 
 # configuration options for the internal call to vagrant
 vagrant:
-  raw_config_args:
-    - "landrush.enabled = true"
-    - "landrush.tld = 'vm'"
-    - "landrush.guest_redirect_dns = false"
-
   # molecule's --platform option will look for these names
   platforms:
     - name: Debian9

--- a/tasks/install_brotli.yml
+++ b/tasks/install_brotli.yml
@@ -27,7 +27,6 @@
 - name: Apache_httpd | Make brotli
   make:
     chdir: "{{ apache_brotli_build_path }}/out"
-  changed_when: false
 
 - name: Apache_httpd | Make test and install
   make:
@@ -36,7 +35,6 @@
   with_items:
     - test
     - install
-  changed_when: false
 
 - name: Apache_httpd | Ldconfig
   command: ldconfig

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,34 +1,41 @@
 ---
-- name: Apache_httpd | Check Apache version
-  command: apachectl -v
-  register: apache_installed_version
-  changed_when: false
-  failed_when: false
-
-- name: Apache_httpd | Install brotli
-  include: install_brotli.yml
+- name: Apache_httpd | Previous checks
+  import_tasks: previous_checks.yml
   tags:
     - install
-  when: apache_brotli_install
+    - brotli
+    - mod_jk
+
+- name: Apache_httpd | Install brotli
+  import_tasks: install_brotli.yml
+  tags:
+    - install
+    - brotli
+  when: >
+    apache_brotli_install and
+    ( apache_brotli_installed_version.rc != 0 or
+    apache_brotli_version | regex_replace('^v','') not in apache_brotli_installed_version.stdout or
+    apache_brotli_reinstall )
 
 - name: Apache_httpd | Install
-  include: install.yml
+  import_tasks: install.yml
   tags:
     - install
   when: apache_installed_version.rc != 0 or apache_version not in apache_installed_version.stdout or apache_reinstall
 
 - name: Apache_httpd | Install mod_jk
-  include: install_modjk.yml
+  import_tasks: install_modjk.yml
   tags:
     - install
+    - mod_jk
   when: apache_modjk_install
 
 - name: Apache_httpd | Config
-  include: config.yml
+  import_tasks: config.yml
   tags:
     - config
 
 - name: Apache_httpd | Service
-  include: service.yml
+  import_tasks: service.yml
   tags:
     - service

--- a/tasks/previous_checks.yml
+++ b/tasks/previous_checks.yml
@@ -1,0 +1,20 @@
+---
+- name: Apache_httpd | Check Apache version
+  command: apachectl -v
+  register: apache_installed_version
+  changed_when: false
+  failed_when: false
+
+- name: Apache_httpd | Set apache_installed_version fact
+  set_fact:
+    apache_installed_version: "{{ apache_installed_version }}"
+
+- name: Apache_httpd | Check Brotli version
+  command: brotli -V
+  register: apache_brotli_installed_version
+  changed_when: false
+  failed_when: false
+
+- name: Apache_httpd | Set apache_brotli_installed_version fact
+  set_fact:
+    apache_brotli_installed_version: "{{ apache_brotli_installed_version }}"


### PR DESCRIPTION
- Update Ansible minimum version to 2.4.0.0
- Update Travis to Ansible 2.4.0.0
- Update Apache, mod_jk and Brotli version. Add apache_brotli_reinstall variable
- Remove changed_when: false in install_brotli.yml make tasks
- Add previous_checks.yml set of tasks, check Brotli version, use import_tasks instead of include
- Force ansible-lint version and testing five different ansible versions 
- Add check mod_jk version