### PR TITLE
Add apache_tags in main.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/apache_httpd-role/tree/develop)
-### Added
-- *Add apache_ tags in main.yml* @jnogol
+### Changed
+- *Add apache_ prefix to install, config and service tags in main.yml* @jnogol
 
 ## [1.8.0](https://github.com/idealista/apache_httpd-role/tree/1.8.0)
 ## [Full Changelog](https://github.com/idealista/apache_httpd-role/compare/1.7.0...1.8.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/apache_httpd-role/tree/develop)
+### Added
+- *Add apache_ tags in main.yml* @jnogol
 
 ## [1.8.0](https://github.com/idealista/apache_httpd-role/tree/1.8.0)
 ## [Full Changelog](https://github.com/idealista/apache_httpd-role/compare/1.7.0...1.8.0)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,16 +3,14 @@
   import_tasks: previous_checks.yml
   tags:
     - apache_install
-    - brotli
-    - install
-    - mod_jk
+    - apache_brotli
+    - apache_mod_jk
 
 - name: Apache_httpd | Install brotli
   import_tasks: install_brotli.yml
   tags:
     - apache_install
-    - brotli
-    - install
+    - apache_brotli
   when: >
     apache_brotli_install and
     ( apache_brotli_installed_version.rc != 0 or
@@ -23,15 +21,13 @@
   import_tasks: install.yml
   tags:
     - apache_install
-    - install
   when: apache_installed_version.rc != 0 or apache_version not in apache_installed_version.stdout or apache_reinstall
 
 - name: Apache_httpd | Install mod_jk
   import_tasks: install_modjk.yml
   tags:
     - apache_install
-    - install
-    - mod_jk
+    - apache_mod_jk
   when: >
     apache_modjk_install and
     ( apache_modjk_installed_version.rc != 0 or
@@ -42,10 +38,8 @@
   import_tasks: config.yml
   tags:
     - apache_config
-    - config
 
 - name: Apache_httpd | Service
   import_tasks: service.yml
   tags:
     - apache_service
-    - service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,15 +2,17 @@
 - name: Apache_httpd | Previous checks
   import_tasks: previous_checks.yml
   tags:
-    - install
+    - apache_install
     - brotli
+    - install
     - mod_jk
 
 - name: Apache_httpd | Install brotli
   import_tasks: install_brotli.yml
   tags:
-    - install
+    - apache_install
     - brotli
+    - install
   when: >
     apache_brotli_install and
     ( apache_brotli_installed_version.rc != 0 or
@@ -20,12 +22,14 @@
 - name: Apache_httpd | Install
   import_tasks: install.yml
   tags:
+    - apache_install
     - install
   when: apache_installed_version.rc != 0 or apache_version not in apache_installed_version.stdout or apache_reinstall
 
 - name: Apache_httpd | Install mod_jk
   import_tasks: install_modjk.yml
   tags:
+    - apache_install
     - install
     - mod_jk
   when: >
@@ -37,9 +41,11 @@
 - name: Apache_httpd | Config
   import_tasks: config.yml
   tags:
+    - apache_config
     - config
 
 - name: Apache_httpd | Service
   import_tasks: service.yml
   tags:
+    - apache_service
     - service


### PR DESCRIPTION
### Description of the Change

Add `apache_*` tags in `main.yml` to all the includes.

### Benefits

When having a big playbook with several roles, these tags will allow us to run more specific tags, saving time.

### Possible Drawbacks

AFAIK, none.